### PR TITLE
Absolute referenzierung vermeiden

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,35 +13,35 @@
     <div class="farbverlauf" >
     <header>
       <a href="https://freifunk-bodensee.net/">
-        <img title="bodensee.freifunk.net" alt="bodensee.freifunk.net" src="https://ffbsee.de/lib/tpl/dokuwiki-template/images/logo.svg"/>
+        <img title="bodensee.freifunk.net" alt="bodensee.freifunk.net" src="/lib/tpl/dokuwiki-template/images/logo.svg"/>
       </a>
     </header>
     <article>
       <figure>
         <a href="https://freifunk-bodensee.net/doku.php?id=WasIstFreifunk">
-          <img title="Was ist Freifunk" alt="Was ist Freifunk" src="https://ffbsee.de/lib/exe/fetch.php?h=180&tok=811d49&media=logo_wifi.png"/>
+          <img title="Was ist Freifunk" alt="Was ist Freifunk" src="/lib/exe/fetch.php?h=180&tok=811d49&media=logo_wifi.png"/>
         </a>
         <h2>Was ist Freifunk?</h2>
         <a>Freifunk ist ein dezentrales, freies Funknetz mit Anschluss ans Internet.
           Hier auf unserer Website erfährst du, welche Ziele wir mit Freifunk verfolgen
           und warum es eine gute Idee ist, sich uns anzuschließen :-)</a>
         <br/><br/>
-        <a class="ff_link" href="https://freifunk-bodensee.net/doku.php?id=WasIstFreifunk">Lerne Freifunk kennen!</a><br/>
+        <a class="ff_link" href="/doku.php?id=WasIstFreifunk">Lerne Freifunk kennen!</a><br/>
       </figure>
       <figure>
-        <a href="https://freifunk-bodensee.net/doku.php?id=mitmachen">
-          <img title="Mach mit!" alt="Mach mit!" src="https://ffbsee.de/lib/exe/fetch.php?h=180&tok=f11ce0&media=mitmachen.png"/>
+        <a href="/doku.php?id=mitmachen">
+          <img title="Mach mit!" alt="Mach mit!" src="/lib/exe/fetch.php?h=180&tok=f11ce0&media=mitmachen.png"/>
         </a>
         <h2>Mach mit und werde Freifunker</h2>
         <a>Auf unserer Website findest du ausführliche Anleitungen, 
           die dir helfen deinen ersten eigenen Freifunk-Router einzurichten.
           Wir freuen uns natürlich auch über anderweitige Mithilfe und Unterstützung.</a>
         <br/><br/>
-        <a class="ff_link" href="https://freifunk-bodensee.net/doku.php?id=mitmachen">Mach mit!</a><br/>
+        <a class="ff_link" href="/doku.php?id=mitmachen">Mach mit!</a><br/>
       </figure>
       <figure>
-        <a href="https://freifunk-bodensee.net/doku.php?id=faq">
-          <img alt="Noch Fragen?" title="Noch Fragen?" src="https://freifunk-bodensee.net/lib/exe/fetch.php?h=180&tok=a83d94&media=fragen.png"/>
+        <a href="/doku.php?id=faq">
+          <img alt="Noch Fragen?" title="Noch Fragen?" src="/lib/exe/fetch.php?h=180&tok=a83d94&media=fragen.png"/>
         </a>
         <h2>Noch Fragen?</h2>
         <a>Du hast Fragen zu Freifunk? 
@@ -49,7 +49,7 @@
           Vielleicht helfen dir unsere Frequently Asked Questions weiter!
           Gern kannst du uns aber auch persönlich oder über die Mailingliste ansprechen.</a>
         <br/><br/>
-        <a class="ff_link" href="https://ffbsee.de/doku.php?id=faq">Zu den FAQs!</a><br/>
+        <a class="ff_link" href="/doku.php?id=faq">Zu den FAQs!</a><br/>
       </figure>
     </article>
 <!--********************************
@@ -59,7 +59,7 @@
 **********************************-->
     <article class="navi">
       <nav>
-        <a class="stoerung" href="https://freifunk-bodensee.net/doku.php?id=stoerung-melden" title="Funktioniert etwas nicht? Sag Bescheid!">Störung Melden</a>
+        <a class="stoerung" href="/doku.php?id=stoerung-melden" title="Funktioniert etwas nicht? Sag Bescheid!">Störung Melden</a>
       </nav>
       <br/><br/>
       <nav>
@@ -125,7 +125,7 @@
     </div>
     <div class="parallax_footer"/>
     <footer>
-    <a href="https://ffbsee.de/impressum">Impressum</a> |
+    <a href="/impressum">Impressum</a> |
     <a href="http://creativecommons.org/licenses/by-sa/4.0/">Lizenz: CC-BY-SA 4.0</a> |
     <a href="https://github.com/ffbsee">Github</a>
     </footer>


### PR DESCRIPTION
In einigen browsern funktionieren mit der absoluten referenzierung (vorallem wenn man von der "falschen" domain kommt, die Bilder nicht. Absoluite refrenzen ueberall entfernt, ausser wo sie explizit Sinn machen (zB rss feed)